### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function read(file, options) {
 	return ensureFile.then((filepath) => new Promise((resolve, reject) => {
 		const args = [
 			'-cp',
-			javasePath + ':' + corePath,
+			javasePath + path.delimiter + corePath,
 			'com.google.zxing.client.j2se.CommandLineRunner',
 			filepath,
 		].concat(params(options));


### PR DESCRIPTION
On Windows, delimiter from UNIX does not work. Simply fix.