### PR TITLE
Update parse-result.js

### DIFF
--- a/lib/parse-result.js
+++ b/lib/parse-result.js
@@ -12,7 +12,7 @@ const UNKNOWN = 'UNKNOWN';
  */
 module.exports = function parse(input) {
 	const output = [];
-	const lines = input.toString().trim().split('/\r\n|\r|\n/');
+	const lines = input.toString().trim().split(/\r\n|\r|\n/);
 	let currentResult = {};
 	let mode = FILE_NAME;
 	let lineBuffer = [];

--- a/lib/parse-result.js
+++ b/lib/parse-result.js
@@ -12,7 +12,7 @@ const UNKNOWN = 'UNKNOWN';
  */
 module.exports = function parse(input) {
 	const output = [];
-	const lines = input.toString().trim().split('\n');
+	const lines = input.toString().trim().split('/\r\n|\r|\n/');
 	let currentResult = {};
 	let mode = FILE_NAME;
 	let lineBuffer = [];


### PR DESCRIPTION
Windows use \r\n to new line, UNIX only \n and Apple only \r. On Windows parsing result return always null because at end of each lines was still \r. Now split is by \r\n or \n or \r.